### PR TITLE
フッターの位置調整

### DIFF
--- a/css/common.css
+++ b/css/common.css
@@ -116,6 +116,22 @@ a {
     line-height: 35px;
 }
 
+@media(max-width:900px){
+    .文3{
+        margin: 0 0 200px 0;
+    }
+}
+
+@media(max-width:452px){
+    .文3{
+        order: -1; /* flexboxの順序変更 */
+        margin: 60px;
+    }
+    .見出し1{
+        margin-top: 10px;
+    }
+}
+
 .矢印 {
     font-family: fot-tsukuardgothic-std, sans-serif;
     font-style: normal;


### PR DESCRIPTION
```CSS
@media(max-width:900px){
    .文3{
        margin: 0 0 200px 0;
    }
}

@media(max-width:452px){
    .文3{
        order: -1; /* flexboxの順序変更 */
        margin: 60px;
    }
    .見出し1{
        margin-top: 10px;
    }
}
```
画面幅に合わせて各コンテンツの間隔（margin）を変更

```CSS
@media(max-width:452px){
    .文3{
        order: -1; /* flexboxの順序変更 */
（※省略）
```
flexbox利用時、inline-flexのコンテンツの並び順は通常、HTMLの記述順に並びます。
CSSでinline-flexのコンテンツにorderを指定することで、
`order`の数値が小さいものから優先されて並びます。
`order`のデフォルト値は0です。

HTMLでは、`文1`、`文3`、`文2`に並んでおり、デフォルトではすべて`order`は0なので
この順に並んでいますが、このように記述することで、
flexの並びが1つだけになる、452px以下になった場合、
`order`が-1の`文3`が最初、続いて`order`が0の`文1`,`文2`の要素がHTMLの並び順に並んでいます。